### PR TITLE
[update]カート画面でアプリ用のgiftIdプロパティが非表示になるように更新

### DIFF
--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -187,7 +187,7 @@
                         {%- for property in item.properties -%}
                           {% if property.first contains '_bogos_trigger' %}{% continue %}{% endif %}
                           {%- assign property_first_char = property.first | slice: 0 -%}
-                          {%- if property.last != blank and property.first != '_preorder_locale' -%}
+                          {%- if property.last != blank and property_first_char != '_' and property.first != '_preorder_locale' -%}
                             <div class="product-option">
                               <dt>{% unless property.first == '_is_preorder' %}{{ property.first }}:{% endunless %}</dt>
                               <dd>


### PR DESCRIPTION
カート画面で表示されるアイテムのプロパティのうち、アンダーバーで始まるものを非表示にするフィルタリングを追加しました。
gwpアプリによって付与された_app_giftIdを非表示にします。