### PR TITLE
Allow repeat add-to-cart within 24 hours after counseling approval

### DIFF
--- a/assets/counseling-modal-shiseido.js
+++ b/assets/counseling-modal-shiseido.js
@@ -8,29 +8,36 @@ function readCounselingApproval(scope) {
   const storageKey = getCounselingStorageKey(scope);
   if (!storageKey) return null;
 
+  const safeRemove = () => {
+    try {
+      window.localStorage.removeItem(storageKey);
+    } catch (_) {
+      // ignore storage access errors
+    }
+  };
+
   try {
     const rawValue = window.localStorage.getItem(storageKey);
     if (!rawValue) return null;
 
     const parsedValue = JSON.parse(rawValue);
     if (!parsedValue || typeof parsedValue !== 'object') {
-      window.localStorage.removeItem(storageKey);
+      safeRemove();
       return null;
     }
 
     if (typeof parsedValue.approvedAt !== 'number' || typeof parsedValue.expiresAt !== 'number') {
-      window.localStorage.removeItem(storageKey);
+      safeRemove();
       return null;
     }
 
     if (parsedValue.expiresAt <= Date.now()) {
-      window.localStorage.removeItem(storageKey);
+      safeRemove();
       return null;
     }
 
     return parsedValue;
   } catch (error) {
-    window.localStorage.removeItem(storageKey);
     return null;
   }
 }
@@ -65,6 +72,7 @@ function submitAssociatedProductForm(triggerButton) {
   if (!form) return;
 
   const originalType = triggerButton.getAttribute('type') || 'submit';
+  triggerButton.dataset.skipCounselingIntercept = '1';
   triggerButton.setAttribute('type', 'submit');
 
   if (typeof form.requestSubmit === 'function') {
@@ -74,6 +82,7 @@ function submitAssociatedProductForm(triggerButton) {
   }
 
   window.setTimeout(() => {
+    delete triggerButton.dataset.skipCounselingIntercept;
     triggerButton.setAttribute('type', originalType);
   }, 0);
 }
@@ -241,6 +250,7 @@ customElements.define('my-dialog', MyDialog);
       button.dataset.counselingTriggerBound = '1';
 
       button.addEventListener('click', (event) => {
+        if (button.dataset.skipCounselingIntercept === '1') return;
         event.preventDefault();
 
         const productForm = button.closest('product-form');

--- a/assets/counseling-modal-shiseido.js
+++ b/assets/counseling-modal-shiseido.js
@@ -1,10 +1,91 @@
-class MyDialog extends HTMLElement {
+const COUNSELING_APPROVAL_WINDOW_MS = 24 * 60 * 60 * 1000;
 
+function getCounselingStorageKey(scope) {
+  return scope ? `counseling:${scope}` : null;
+}
+
+function readCounselingApproval(scope) {
+  const storageKey = getCounselingStorageKey(scope);
+  if (!storageKey) return null;
+
+  try {
+    const rawValue = window.localStorage.getItem(storageKey);
+    if (!rawValue) return null;
+
+    const parsedValue = JSON.parse(rawValue);
+    if (!parsedValue || typeof parsedValue !== 'object') {
+      window.localStorage.removeItem(storageKey);
+      return null;
+    }
+
+    if (typeof parsedValue.approvedAt !== 'number' || typeof parsedValue.expiresAt !== 'number') {
+      window.localStorage.removeItem(storageKey);
+      return null;
+    }
+
+    if (parsedValue.expiresAt <= Date.now()) {
+      window.localStorage.removeItem(storageKey);
+      return null;
+    }
+
+    return parsedValue;
+  } catch (error) {
+    window.localStorage.removeItem(storageKey);
+    return null;
+  }
+}
+
+function persistCounselingApproval(scope) {
+  const storageKey = getCounselingStorageKey(scope);
+  if (!storageKey) return;
+
+  const approvedAt = Date.now();
+  const expiresAt = approvedAt + COUNSELING_APPROVAL_WINDOW_MS;
+
+  try {
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        approvedAt,
+        expiresAt,
+      })
+    );
+  } catch (error) {
+    console.error('Failed to persist counseling approval state.', error);
+  }
+}
+
+function hasValidCounselingApproval(scope) {
+  return Boolean(readCounselingApproval(scope));
+}
+
+function submitAssociatedProductForm(triggerButton) {
+  const productForm = triggerButton.closest('product-form');
+  const form = productForm ? productForm.querySelector('form') : null;
+  if (!form) return;
+
+  const originalType = triggerButton.getAttribute('type') || 'submit';
+  triggerButton.setAttribute('type', 'submit');
+
+  if (typeof form.requestSubmit === 'function') {
+    form.requestSubmit(triggerButton);
+  } else {
+    triggerButton.click();
+  }
+
+  window.setTimeout(() => {
+    triggerButton.setAttribute('type', originalType);
+  }, 0);
+}
+
+class MyDialog extends HTMLElement {
   constructor() {
     super();
     this.activePageIndex = 0;
     this.dialog = this.querySelector('dialog');
-    dialogPolyfill.registerDialog(this.dialog);
+    if (this.dialog && typeof dialogPolyfill !== 'undefined') {
+      dialogPolyfill.registerDialog(this.dialog);
+    }
     this.pages = this.querySelectorAll('.page');
     this.closeButtons = this.querySelectorAll('.close-button');
     this.nextPageButtons = this.querySelectorAll('.next-page');
@@ -14,6 +95,8 @@ class MyDialog extends HTMLElement {
     this.submitButtons = this.querySelectorAll('button[type="submit"]');
     this.q1_1 = this.querySelector('.q1_1');
     this.retryCounselingButton = this.querySelector('.retry-counseling');
+    this.counselingScope = this.getAttribute('data-counseling-scope') || '';
+    this.currentResultIndex = null;
   }
 
   connectedCallback() {
@@ -23,19 +106,22 @@ class MyDialog extends HTMLElement {
       }
     });
 
-    this.submitButtons.forEach(submitButton => {
+    this.submitButtons.forEach((submitButton) => {
       submitButton.addEventListener('click', () => {
+        if (this.isPurchasableResult(this.currentResultIndex)) {
+          persistCounselingApproval(this.counselingScope);
+        }
         this.dialog.close();
       });
     });
 
-    this.closeButtons.forEach(closeButton => {
+    this.closeButtons.forEach((closeButton) => {
       closeButton.addEventListener('click', () => {
         this.dialog.close();
       });
     });
 
-    this.nextPageButtons.forEach(nextPageButton => {
+    this.nextPageButtons.forEach((nextPageButton) => {
       nextPageButton.addEventListener('click', () => {
         this.nextPage();
       });
@@ -43,7 +129,7 @@ class MyDialog extends HTMLElement {
 
     this.pages[this.activePageIndex].classList.add('active');
 
-    Array.from(this.radioButtons).forEach(radioButton => {
+    Array.from(this.radioButtons).forEach((radioButton) => {
       radioButton.addEventListener('change', () => {
         this.checkNextButtonActive();
       });
@@ -55,14 +141,12 @@ class MyDialog extends HTMLElement {
   }
 
   checkNextButtonActive() {
-    // Assuming all questions have 2 choices, each question must have at least 1 selected
-    let radioGroup1 = Array.from(this.querySelectorAll('input[name="q1"]')).some(radio => radio.checked);
-    let radioGroup2 = Array.from(this.querySelectorAll('input[name="q2"]')).some(radio => radio.checked);
-    let radioGroup3 = Array.from(this.querySelectorAll('input[name="q3"]')).some(radio => radio.checked);
+    const radioGroup1 = Array.from(this.querySelectorAll('input[name="q1"]')).some((radio) => radio.checked);
+    const radioGroup2 = Array.from(this.querySelectorAll('input[name="q2"]')).some((radio) => radio.checked);
+    const radioGroup3 = Array.from(this.querySelectorAll('input[name="q3"]')).some((radio) => radio.checked);
     if (this.radioButtons[0].checked) {
-      // q1_1のtw-hiddenクラスを削除
       this.q1_1.classList.remove('tw-hidden');
-      if(radioGroup1 && radioGroup2) {
+      if (radioGroup1 && radioGroup2) {
         this.nextPageDisableButtons[0].style.display = 'none';
         this.nextPageButtons[0].style.display = 'block';
       } else {
@@ -70,7 +154,7 @@ class MyDialog extends HTMLElement {
         this.nextPageDisableButtons[0].style.display = 'block';
       }
 
-      if(radioGroup1 && radioGroup2 && radioGroup3) {
+      if (radioGroup1 && radioGroup2 && radioGroup3) {
         this.nextPageDisableButtons[1].style.display = 'none';
         this.nextPageButtons[1].style.display = 'block';
       } else {
@@ -78,16 +162,15 @@ class MyDialog extends HTMLElement {
         this.nextPageDisableButtons[1].style.display = 'block';
       }
     } else {
-      // q1_1のtw-hiddenクラスを追加
       this.q1_1.classList.add('tw-hidden');
-      if(radioGroup1) {
+      if (radioGroup1) {
         this.nextPageDisableButtons[0].style.display = 'none';
         this.nextPageButtons[0].style.display = 'block';
       } else {
         this.nextPageButtons[0].style.display = 'none';
         this.nextPageDisableButtons[0].style.display = 'block';
       }
-      if(radioGroup1 && radioGroup3) {
+      if (radioGroup1 && radioGroup3) {
         this.nextPageDisableButtons[1].style.display = 'none';
         this.nextPageButtons[1].style.display = 'block';
       } else {
@@ -100,14 +183,19 @@ class MyDialog extends HTMLElement {
   retryCounseling() {
     this.pages[this.activePageIndex].classList.remove('active');
     this.activePageIndex = 0;
+    this.currentResultIndex = null;
     this.pages[this.activePageIndex].classList.add('active');
-    this.radioButtons.forEach(radioButton => {
+    this.radioButtons.forEach((radioButton) => {
       radioButton.checked = false;
     });
-    this.counselingResult.forEach(counselingResult => {
+    this.counselingResult.forEach((counselingResult) => {
       counselingResult.classList.remove('active');
     });
     this.checkNextButtonActive();
+  }
+
+  isPurchasableResult(resultIndex) {
+    return resultIndex === 0 || resultIndex === 2;
   }
 
   openDialog() {
@@ -115,51 +203,67 @@ class MyDialog extends HTMLElement {
   }
 
   nextPage() {
-    if(this.activePageIndex + 1 < this.pages.length) {
+    if (this.activePageIndex + 1 < this.pages.length) {
       this.pages[this.activePageIndex].classList.remove('active');
       this.activePageIndex++;
       this.pages[this.activePageIndex].classList.add('active');
     }
-    if(this.activePageIndex === 2) {
+    if (this.activePageIndex === 2) {
       this.updateLastPage();
     }
   }
 
   updateLastPage() {
-    if(this.radioButtons[1].checked && this.radioButtons[5].checked) {
-      this.counselingResult[0].classList.add('active');
-    } else if(this.radioButtons[0].checked && this.radioButtons[3].checked) {
-      this.counselingResult[1].classList.add('active');
+    this.counselingResult.forEach((counselingResult) => {
+      counselingResult.classList.remove('active');
+    });
+
+    if (this.radioButtons[1].checked && this.radioButtons[5].checked) {
+      this.currentResultIndex = 0;
+    } else if (this.radioButtons[0].checked && this.radioButtons[3].checked) {
+      this.currentResultIndex = 1;
     } else {
-      this.counselingResult[2].classList.add('active');
+      this.currentResultIndex = 2;
     }
+
+    this.counselingResult[this.currentResultIndex].classList.add('active');
   }
 }
 
 customElements.define('my-dialog', MyDialog);
 
-// TODO:: 以下の処理を適切な形にリファクタリング
-let counter = 0;
-const maxIterations = 10;
-const interval = setInterval(() => {
-  console.log(counter);
-  const allButtons = Array.from(document.querySelectorAll('button[type="button"]'));
-  allButtons.filter(button => button.id.includes('ProductSubmitButton')).forEach(targetedButton => {
-    targetedButton.addEventListener('click', () => {
-      document.querySelector('my-dialog').openDialog();
+(function () {
+  function initCounselingTriggers() {
+    const triggerButtons = document.querySelectorAll('[data-counseling-trigger]');
+
+    triggerButtons.forEach((button) => {
+      if (button.dataset.counselingTriggerBound === '1') return;
+      button.dataset.counselingTriggerBound = '1';
+
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+
+        const productForm = button.closest('product-form');
+        const dialog = productForm ? productForm.querySelector('my-dialog') : null;
+        const counselingScope = productForm ? productForm.dataset.counselingScope : '';
+
+        if (counselingScope && hasValidCounselingApproval(counselingScope)) {
+          submitAssociatedProductForm(button);
+          return;
+        }
+
+        if (dialog) {
+          dialog.openDialog();
+        }
+      });
     });
-  });
-  if (allButtons.filter(button => button.id.includes('ProductSubmitButton')).length >= 2) {
-    clearInterval(interval);
   }
-  if (counter >= maxIterations) {
-    clearInterval(interval);
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initCounselingTriggers);
+  } else {
+    initCounselingTriggers();
   }
-  counter++;
-}, 500);
-// const allButtons = Array.from(document.querySelectorAll('button[type="button"]'));
-// allButtons.filter(button => button.id.includes('ProductSubmitButton')).forEach(targetedButton => {
-//   targetedButton.addEventListener('click', () => {
-//     document.querySelector('my-dialog').openDialog();
-//   });
-// });
+
+  window.setTimeout(initCounselingTriggers, 500);
+})();

--- a/assets/counseling-modal.js
+++ b/assets/counseling-modal.js
@@ -12,29 +12,36 @@ function readCounselingApproval(scope) {
   const storageKey = getCounselingStorageKey(scope);
   if (!storageKey) return null;
 
+  const safeRemove = () => {
+    try {
+      window.localStorage.removeItem(storageKey);
+    } catch (_) {
+      // ignore storage access errors
+    }
+  };
+
   try {
     const rawValue = window.localStorage.getItem(storageKey);
     if (!rawValue) return null;
 
     const parsedValue = JSON.parse(rawValue);
     if (!parsedValue || typeof parsedValue !== 'object') {
-      window.localStorage.removeItem(storageKey);
+      safeRemove();
       return null;
     }
 
     if (typeof parsedValue.approvedAt !== 'number' || typeof parsedValue.expiresAt !== 'number') {
-      window.localStorage.removeItem(storageKey);
+      safeRemove();
       return null;
     }
 
     if (parsedValue.expiresAt <= Date.now()) {
-      window.localStorage.removeItem(storageKey);
+      safeRemove();
       return null;
     }
 
     return parsedValue;
   } catch (error) {
-    window.localStorage.removeItem(storageKey);
     return null;
   }
 }
@@ -69,6 +76,7 @@ function submitAssociatedProductForm(triggerButton) {
   if (!form) return;
 
   const originalType = triggerButton.getAttribute('type') || 'submit';
+  triggerButton.dataset.skipCounselingIntercept = '1';
   triggerButton.setAttribute('type', 'submit');
 
   if (typeof form.requestSubmit === 'function') {
@@ -78,6 +86,7 @@ function submitAssociatedProductForm(triggerButton) {
   }
 
   window.setTimeout(() => {
+    delete triggerButton.dataset.skipCounselingIntercept;
     triggerButton.setAttribute('type', originalType);
   }, 0);
 }
@@ -140,7 +149,9 @@ class MyDialog extends HTMLElement {
         this.pages.forEach((p, i) => p.classList.toggle('active', i === 0));
         this.activePageIndex = 0;
         this.currentResultIndex = null;
-        this.counselingResult.forEach((result) => result.classList.remove('active'));
+        this.counselingResult.forEach((result) => {
+          result.classList.remove('active');
+        });
         if (this.useCheckbox && this.checkboxes.length === 3) {
           this.checkboxes.forEach((cb) => { cb.checked = false; });
           this.checkNextButtonActive();
@@ -242,7 +253,9 @@ class MyDialog extends HTMLElement {
       if (q1Value === null || q2Value === null || q3Value === null) return;
     }
 
-    this.counselingResult.forEach((result) => result.classList.remove('active'));
+    this.counselingResult.forEach((result) => {
+          result.classList.remove('active');
+        });
 
     const resultIndex = this.getResultIndex(q1Value, q2Value, q3Value);
     this.currentResultIndex = resultIndex;
@@ -300,6 +313,7 @@ customElements.define('my-dialog', MyDialog);
       button.dataset.counselingTriggerBound = '1';
 
       button.addEventListener('click', (event) => {
+        if (button.dataset.skipCounselingIntercept === '1') return;
         event.preventDefault();
 
         const productForm = button.closest('product-form');

--- a/assets/counseling-modal.js
+++ b/assets/counseling-modal.js
@@ -2,6 +2,86 @@
  * Brand-agnostic counseling modal component
  * Uses data attributes for configuration to support multiple brands
  */
+const COUNSELING_APPROVAL_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+function getCounselingStorageKey(scope) {
+  return scope ? `counseling:${scope}` : null;
+}
+
+function readCounselingApproval(scope) {
+  const storageKey = getCounselingStorageKey(scope);
+  if (!storageKey) return null;
+
+  try {
+    const rawValue = window.localStorage.getItem(storageKey);
+    if (!rawValue) return null;
+
+    const parsedValue = JSON.parse(rawValue);
+    if (!parsedValue || typeof parsedValue !== 'object') {
+      window.localStorage.removeItem(storageKey);
+      return null;
+    }
+
+    if (typeof parsedValue.approvedAt !== 'number' || typeof parsedValue.expiresAt !== 'number') {
+      window.localStorage.removeItem(storageKey);
+      return null;
+    }
+
+    if (parsedValue.expiresAt <= Date.now()) {
+      window.localStorage.removeItem(storageKey);
+      return null;
+    }
+
+    return parsedValue;
+  } catch (error) {
+    window.localStorage.removeItem(storageKey);
+    return null;
+  }
+}
+
+function persistCounselingApproval(scope) {
+  const storageKey = getCounselingStorageKey(scope);
+  if (!storageKey) return;
+
+  const approvedAt = Date.now();
+  const expiresAt = approvedAt + COUNSELING_APPROVAL_WINDOW_MS;
+
+  try {
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        approvedAt,
+        expiresAt,
+      })
+    );
+  } catch (error) {
+    console.error('Failed to persist counseling approval state.', error);
+  }
+}
+
+function hasValidCounselingApproval(scope) {
+  return Boolean(readCounselingApproval(scope));
+}
+
+function submitAssociatedProductForm(triggerButton) {
+  const productForm = triggerButton.closest('product-form');
+  const form = productForm ? productForm.querySelector('form') : null;
+  if (!form) return;
+
+  const originalType = triggerButton.getAttribute('type') || 'submit';
+  triggerButton.setAttribute('type', 'submit');
+
+  if (typeof form.requestSubmit === 'function') {
+    form.requestSubmit(triggerButton);
+  } else {
+    triggerButton.click();
+  }
+
+  window.setTimeout(() => {
+    triggerButton.setAttribute('type', originalType);
+  }, 0);
+}
+
 class MyDialog extends HTMLElement {
   constructor() {
     super();
@@ -26,6 +106,8 @@ class MyDialog extends HTMLElement {
     this.nextPageDisableButton = this.querySelector('.next-page-disable');
     this.submitButtons = this.querySelectorAll('button[type="submit"]');
     this.brand = this.getAttribute('data-brand') || 'default';
+    this.counselingScope = this.getAttribute('data-counseling-scope') || '';
+    this.currentResultIndex = null;
   }
 
   connectedCallback() {
@@ -39,6 +121,9 @@ class MyDialog extends HTMLElement {
 
     this.submitButtons.forEach((submitButton) => {
       submitButton.addEventListener('click', () => {
+        if (this.isPurchasableResult(this.currentResultIndex)) {
+          persistCounselingApproval(this.counselingScope);
+        }
         this.dialog.close();
       });
     });
@@ -54,6 +139,8 @@ class MyDialog extends HTMLElement {
       btn.addEventListener('click', () => {
         this.pages.forEach((p, i) => p.classList.toggle('active', i === 0));
         this.activePageIndex = 0;
+        this.currentResultIndex = null;
+        this.counselingResult.forEach((result) => result.classList.remove('active'));
         if (this.useCheckbox && this.checkboxes.length === 3) {
           this.checkboxes.forEach((cb) => { cb.checked = false; });
           this.checkNextButtonActive();
@@ -102,11 +189,10 @@ class MyDialog extends HTMLElement {
       }
       return;
     }
-    // Assuming all questions have 2 choices, each question must have at least 1 selected
-    // Support both old format (q1, q2, q3) and new format (q1-{section_id}, q2-{section_id}, q3-{section_id})
-    let radioGroup1 = Array.from(this.querySelectorAll('input[name^="q1"]')).some((radio) => radio.checked);
-    let radioGroup2 = Array.from(this.querySelectorAll('input[name^="q2"]')).some((radio) => radio.checked);
-    let radioGroup3 = Array.from(this.querySelectorAll('input[name^="q3"]')).some((radio) => radio.checked);
+
+    const radioGroup1 = Array.from(this.querySelectorAll('input[name^="q1"]')).some((radio) => radio.checked);
+    const radioGroup2 = Array.from(this.querySelectorAll('input[name^="q2"]')).some((radio) => radio.checked);
+    const radioGroup3 = Array.from(this.querySelectorAll('input[name^="q3"]')).some((radio) => radio.checked);
     if (radioGroup1 && radioGroup2 && radioGroup3) {
       if (this.nextPageDisableButton) {
         this.nextPageDisableButton.style.display = 'none';
@@ -140,7 +226,9 @@ class MyDialog extends HTMLElement {
   }
 
   updateSecondPage() {
-    let q1Value, q2Value, q3Value;
+    let q1Value;
+    let q2Value;
+    let q3Value;
 
     if (this.useCheckbox && this.checkboxes.length === 3) {
       q1Value = this.checkboxes[0].checked ? 1 : 0;
@@ -148,23 +236,32 @@ class MyDialog extends HTMLElement {
       q3Value = this.checkboxes[2].checked ? 1 : 0;
     } else {
       if (this.radioButtons.length < 6) return;
-      // Get radio button values: q1, q2, q3 (YES=1, NO=0)
-      // Radio buttons are ordered: q1_YES, q1_NO, q2_YES, q2_NO, q3_YES, q3_NO
       q1Value = this.radioButtons[0].checked ? 1 : this.radioButtons[1].checked ? 0 : null;
       q2Value = this.radioButtons[2].checked ? 1 : this.radioButtons[3].checked ? 0 : null;
       q3Value = this.radioButtons[4].checked ? 1 : this.radioButtons[5].checked ? 0 : null;
       if (q1Value === null || q2Value === null || q3Value === null) return;
     }
 
-    // Reset all results first
     this.counselingResult.forEach((result) => result.classList.remove('active'));
 
-    // Brand-specific result logic
-    let resultIndex = this.getResultIndex(q1Value, q2Value, q3Value);
+    const resultIndex = this.getResultIndex(q1Value, q2Value, q3Value);
+    this.currentResultIndex = resultIndex;
 
     if (this.counselingResult[resultIndex]) {
       this.counselingResult[resultIndex].classList.add('active');
     }
+  }
+
+  isPurchasableResult(resultIndex) {
+    if (resultIndex === null || resultIndex === undefined) {
+      return false;
+    }
+
+    if (this.brand === 'albion') {
+      return resultIndex === 0 || resultIndex === 1;
+    }
+
+    return resultIndex === 0 || resultIndex === 1;
   }
 
   /**
@@ -172,66 +269,60 @@ class MyDialog extends HTMLElement {
    * Override this method or extend the logic for brand-specific behavior
    */
   getResultIndex(q1, q2, q3) {
-    // Default logic (Decorte style)
-    // Result 0: All NO (q1=0, q2=0, q3=0) - 購入前カウンセリングが完了しました
-    // Result 1: q1=NO and (q2=YES or q3=YES) - ご購入にあたっては商品情報をご確認ください
-    // Result 2: q1=YES - 販売できません
-
     if (this.brand === 'albion') {
-      // Albion: 否定文でチェック=YES（当てはまる）. ガイドライン判定ロジック
-      // Q1=YES,Q2=YES,Q3=YES -> 購入可 | Q1=YESかつ(Q2=NO or Q3=NO) -> 注意喚起 | それ以外 -> 購入不可
       if (q1 === 1 && q2 === 1 && q3 === 1) {
-        return 0; // アルゴリズム① 購入可
+        return 0;
       }
       if (q1 === 1 && (q2 === 0 || q3 === 0)) {
-        return 1; // アルゴリズム② 注意喚起
+        return 1;
       }
-      return 2; // アルゴリズム③ 購入不可
+      return 2;
+    }
+
+    if (q1 === 0 && q2 === 0 && q3 === 0) {
+      return 0;
+    } else if (q1 === 0 && (q2 === 1 || q3 === 1)) {
+      return 1;
     } else {
-      // Decorte/default logic
-      if (q1 === 0 && q2 === 0 && q3 === 0) {
-        return 0; // All NO
-      } else if (q1 === 0 && (q2 === 1 || q3 === 1)) {
-        return 1; // q1=NO and (q2=YES or q3=YES)
-      } else {
-        return 2; // q1=YES (cannot sell)
-      }
+      return 2;
     }
   }
 }
 
 customElements.define('my-dialog', MyDialog);
 
-/**
- * Initialize counseling modal triggers
- * Looks for buttons with data-counseling-trigger attribute
- */
 (function () {
   function initCounselingTriggers() {
     const triggerButtons = document.querySelectorAll('[data-counseling-trigger]');
-    const dialog = document.querySelector('my-dialog');
-
-    if (!dialog) return;
 
     triggerButtons.forEach((button) => {
-      // Remove existing listeners by cloning
-      const newButton = button.cloneNode(true);
-      button.parentNode.replaceChild(newButton, button);
+      if (button.dataset.counselingTriggerBound === '1') return;
+      button.dataset.counselingTriggerBound = '1';
 
-      newButton.addEventListener('click', (e) => {
-        e.preventDefault();
-        dialog.openDialog();
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+
+        const productForm = button.closest('product-form');
+        const dialog = productForm ? productForm.querySelector('my-dialog') : null;
+        const counselingScope = productForm ? productForm.dataset.counselingScope : '';
+
+        if (counselingScope && hasValidCounselingApproval(counselingScope)) {
+          submitAssociatedProductForm(button);
+          return;
+        }
+
+        if (dialog) {
+          dialog.openDialog();
+        }
       });
     });
   }
 
-  // Initialize on DOM ready
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', initCounselingTriggers);
   } else {
     initCounselingTriggers();
   }
 
-  // Also try after a short delay for dynamically loaded content
-  setTimeout(initCounselingTriggers, 500);
+  window.setTimeout(initCounselingTriggers, 500);
 })();

--- a/assets/counseling-modal.js
+++ b/assets/counseling-modal.js
@@ -254,8 +254,8 @@ class MyDialog extends HTMLElement {
     }
 
     this.counselingResult.forEach((result) => {
-          result.classList.remove('active');
-        });
+      result.classList.remove('active');
+    });
 
     const resultIndex = this.getResultIndex(q1Value, q2Value, q3Value);
     this.currentResultIndex = resultIndex;

--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -18,13 +18,17 @@ if (!customElements.get('product-form')) {
 
       onSubmitHandler(evt) {
         evt.preventDefault();
+        this.submitButton = evt.submitter || this.querySelector('[type="submit"]');
         if (this.submitButton.getAttribute('aria-disabled') === 'true') return;
 
         this.handleErrorMessage();
 
         this.submitButton.setAttribute('aria-disabled', true);
         this.submitButton.classList.add('loading');
-        this.querySelector('.loading__spinner').classList.remove('hidden');
+        const loadingSpinner = this.submitButton.querySelector('.loading__spinner') || this.querySelector('.loading__spinner');
+        if (loadingSpinner) {
+          loadingSpinner.classList.remove('hidden');
+        }
 
         const config = fetchConfig('javascript');
         config.headers['X-Requested-With'] = 'XMLHttpRequest';
@@ -101,7 +105,9 @@ if (!customElements.get('product-form')) {
             this.submitButton.classList.remove('loading');
             if (this.cart && this.cart.classList.contains('is-empty')) this.cart.classList.remove('is-empty');
             if (!this.error) this.submitButton.removeAttribute('aria-disabled');
-            this.querySelector('.loading__spinner').classList.add('hidden');
+            if (loadingSpinner) {
+              loadingSpinner.classList.add('hidden');
+            }
           });
       }
 

--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -37,14 +37,12 @@
           {%- if section.blocks.first.settings.link != blank -%}
             <a
               href="{{ section.blocks.first.settings.link }}"
-              class="announcement-bar__link link link--text focus-inset animate-arrow"
+              class="announcement-bar__link link link--text focus-inset"
+              style="text-decoration: underline; text-decoration-color: white; text-underline-offset: 3px;"
             >
           {%- endif -%}
           <p class="announcement-bar__message h5">
             <span>{{ section.blocks.first.settings.text | escape }}</span>
-            {%- if section.blocks.first.settings.link != blank -%}
-              {% render 'icon-arrow' %}
-            {%- endif -%}
           </p>
           {%- if section.blocks.first.settings.link != blank -%}
             </a>
@@ -96,14 +94,12 @@
                     {%- if block.settings.link != blank -%}
                       <a
                         href="{{ block.settings.link }}"
-                        class="announcement-bar__link link link--text focus-inset animate-arrow"
+                        class="announcement-bar__link link link--text focus-inset"
+                        style="text-decoration: underline; text-decoration-color: white; text-underline-offset: 3px;"
                       >
                     {%- endif -%}
                     <p class="announcement-bar__message h5">
                       <span>{{ block.settings.text | escape }}</span>
-                      {%- if block.settings.link != blank -%}
-                        {% render 'icon-arrow' %}
-                      {%- endif -%}
                     </p>
                     {%- if block.settings.link != blank -%}
                       </a>

--- a/sections/main-collection-product-grid-albion.liquid
+++ b/sections/main-collection-product-grid-albion.liquid
@@ -122,19 +122,8 @@
   assign show_desktop_slider = false
   assign show_desktop_slider = true
 
-  # Determine selected tag from Storefront Filtering (filter.p.tag) または旧来の current_tags
-  assign filter_tag = ''
-  for filter in collection.filters
-    if filter.param_name == 'filter.p.tag'
-      if filter.active_values != blank
-        assign filter_tag = filter.active_values.first.label
-      endif
-      break
-    endif
-  endfor
-  if filter_tag == ''
-    assign filter_tag = current_tags | first
-  endif
+  # Determine selected tag from /collections/{handle}/{tag} 形式のタグフィルタリング
+  assign filter_tag = current_tags | first
 
   assign is_new_items_template = false
   if template.suffix contains 'new-items'
@@ -397,31 +386,6 @@
     </div>
     <!-- Albion商品一覧ここまで -->
   {% else %}
-    {% comment %}
-      Storefront Filtering API で filter.p.tag の値が解決できなかった場合、
-      /collections/{handle}/{tag} 形式のタグURLフィルタリングにフォールバックする。
-      参考: https://shopify.dev/docs/storefronts/themes/navigation-search/filtering/tag-filtering
-    {% endcomment %}
-    <script>
-      (function() {
-        var params = new URLSearchParams(window.location.search);
-        var filterTags = params.getAll('filter.p.tag');
-        if (filterTags.length > 0) {
-          var tags = [];
-          filterTags.forEach(function(ft) {
-            ft.split(',').forEach(function(t) {
-              var trimmed = t.trim();
-              if (trimmed) tags.push(trimmed);
-            });
-          });
-          if (tags.length > 0) {
-            var collectionUrl = {{ collection.url | json }};
-            var hash = window.location.hash || '#Collection';
-            window.location.replace(collectionUrl + '/' + tags[0] + hash);
-          }
-        }
-      })();
-    </script>
     <!-- Albionブランドトップ -->
     <div class="page-width">
       {%- if section.settings.new_arrival_collection != blank -%}

--- a/snippets/albion-nav-items.liquid
+++ b/snippets/albion-nav-items.liquid
@@ -11,65 +11,65 @@
     <div class="tw-hidden md:tw-flex md:tw-w-full md:tw-justify-center tw-bg-white tw-text-gray-900 tw-border-b tw-border-gray-200">
       {% comment %} スキンケア {% endcomment %}
       <div class="tw-group tw-relative tw-text-left hover:tw-bg-gray-100 tw-bg-white tw-text-gray-900">
-        <a class="tw-h-10 tw-px-4 tw-py-2 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=スキンケア#Collection">
+        <a class="tw-h-10 tw-px-4 tw-py-2 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/スキンケア#Collection">
           スキンケア
           <i aria-hidden="true" class="tw-inline-flex tw-text-2xl tw-leading-none notranslate mdi mdi-chevron-right tw-no-underline tw-text-black"></i>
         </a>
         <div class="nested-menu group-hover:tw-block tw-hidden tw-bg-white tw-text-gray-900 tw-border tw-border-gray-200 tw-shadow-md">
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=クレンジング#Collection">クレンジング</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=洗顔料#Collection">洗顔料</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=乳液#Collection">乳液</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=化粧水#Collection">化粧水</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=美容液#Collection">美容液</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=クリーム#Collection">クリーム</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=マッサージ#Collection">マッサージ</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=パック,マスク#Collection">パック</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=美容オイル#Collection">美容オイル</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=アイケア#Collection">アイケア</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=リップケア#Collection">リップケア</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=スペシャルケア#Collection">スペシャルケア・その他</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/クレンジング#Collection">クレンジング</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/洗顔料#Collection">洗顔料</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/乳液#Collection">乳液</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/化粧水#Collection">化粧水</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/美容液#Collection">美容液</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/クリーム#Collection">クリーム</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/マッサージ#Collection">マッサージ</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/パック,マスク#Collection">パック</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/美容オイル#Collection">美容オイル</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/アイケア#Collection">アイケア</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/リップケア#Collection">リップケア</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/スペシャルケア#Collection">スペシャルケア・その他</a>
         </div>
       </div>
       {% comment %} ベースメイク {% endcomment %}
       <div class="tw-group tw-relative tw-text-left hover:tw-bg-gray-100 tw-bg-white tw-text-gray-900">
-        <a class="tw-h-10 tw-px-4 tw-py-2 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=ベースメイク#Collection">
+        <a class="tw-h-10 tw-px-4 tw-py-2 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/ベースメイク#Collection">
           ベースメイク
           <i aria-hidden="true" class="tw-inline-flex tw-text-2xl tw-leading-none notranslate mdi mdi-chevron-right tw-no-underline tw-text-black"></i>
         </a>
         <div class="nested-menu group-hover:tw-block tw-hidden tw-bg-white tw-text-gray-900 tw-border tw-border-gray-200 tw-shadow-md">
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=ファンデーション#Collection">ファンデーション</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=メイクアップベース#Collection">メイクアップベース</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=コンシーラー#Collection">コンシーラー</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=フェイスパウダー#Collection">フェイスパウダー</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/ファンデーション#Collection">ファンデーション</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/メイクアップベース#Collection">メイクアップベース</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/コンシーラー#Collection">コンシーラー</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/フェイスパウダー#Collection">フェイスパウダー</a>
         </div>
       </div>
       {% comment %} ポイントメイク {% endcomment %}
       <div class="tw-group tw-relative tw-text-left hover:tw-bg-gray-100 tw-bg-white tw-text-gray-900">
-        <a class="tw-h-10 tw-px-4 tw-py-2 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=ポイントメイク#Collection">
+        <a class="tw-h-10 tw-px-4 tw-py-2 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/ポイントメイク#Collection">
           ポイントメイク
           <i aria-hidden="true" class="tw-inline-flex tw-text-2xl tw-leading-none notranslate mdi mdi-chevron-right tw-no-underline tw-text-black"></i>
         </a>
         <div class="nested-menu group-hover:tw-block tw-hidden tw-bg-white tw-text-gray-900 tw-border tw-border-gray-200 tw-shadow-md">
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=アイメイク#Collection">アイメイク</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=リップメイク#Collection">リップメイク</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=チーク,ブラッシュ#Collection">チーク・フェイスカラー</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=ネイルカラー#Collection">ネイル</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=ネイルケア,リムーバー#Collection">ネイルリムーバー</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=ポイントメイクオフ#Collection">ポイントメイクオフ</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/アイメイク#Collection">アイメイク</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/リップメイク#Collection">リップメイク</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/チーク,ブラッシュ#Collection">チーク・フェイスカラー</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/ネイルカラー#Collection">ネイル</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/ネイルケア,リムーバー#Collection">ネイルリムーバー</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/ポイントメイクオフ#Collection">ポイントメイクオフ</a>
         </div>
       </div>
       {% comment %} UV・ボディ・その他 {% endcomment %}
       <div class="tw-group tw-relative tw-text-left hover:tw-bg-gray-100 tw-bg-white tw-text-gray-900">
-        <a class="tw-h-10 tw-px-4 tw-py-2 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=UVケア,アウトバストリートメント,ヘアケア,コットン,アクセサリー#Collection">
+        <a class="tw-h-10 tw-px-4 tw-py-2 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/UVケア,アウトバストリートメント,ヘアケア,コットン,アクセサリー#Collection">
           UV・ボディ・その他
           <i aria-hidden="true" class="tw-inline-flex tw-text-2xl tw-leading-none notranslate mdi mdi-chevron-right tw-no-underline tw-text-black"></i>
         </a>
         <div class="nested-menu group-hover:tw-block tw-hidden tw-bg-white tw-text-gray-900 tw-border tw-border-gray-200 tw-shadow-md">
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=UVケア#Collection">UVケア</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=アウトバストリートメント#Collection">ハンド・ボディケア</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=ヘアケア#Collection">ヘアケア</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=コットン#Collection">コットン</a>
-          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=アクセサリー#Collection">その他</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/UVケア#Collection">UVケア</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/アウトバストリートメント#Collection">ハンド・ボディケア</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/ヘアケア#Collection">ヘアケア</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/コットン#Collection">コットン</a>
+          <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/アクセサリー#Collection">その他</a>
         </div>
       </div>
       {% comment %} オンラインカウンセリング {% endcomment %}
@@ -92,18 +92,18 @@
         </span>
       </div>
       <div class="panel tw-bg-gray-50 tw-text-gray-900">
-        <a href="{{ albion_collection_url }}?filter.p.tag=クレンジング#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>クレンジング</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=洗顔料#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>洗顔料</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=乳液#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>乳液</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=化粧水#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>化粧水</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=美容液#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>美容液</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=クリーム#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>クリーム</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=マッサージ#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>マッサージ</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=パック,マスク#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>パック</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=美容オイル#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>美容オイル</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=アイケア#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>アイケア</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=リップケア#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>リップケア</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=スペシャルケア#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>スペシャルケア・その他</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/クレンジング#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>クレンジング</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/洗顔料#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>洗顔料</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/乳液#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>乳液</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/化粧水#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>化粧水</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/美容液#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>美容液</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/クリーム#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>クリーム</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/マッサージ#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>マッサージ</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/パック,マスク#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>パック</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/美容オイル#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>美容オイル</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/アイケア#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>アイケア</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/リップケア#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>リップケア</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/スペシャルケア#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>スペシャルケア・その他</span><i class="mdi mdi-chevron-right"></i></a>
       </div>
     </li>
     {% comment %} ベースメイク {% endcomment %}
@@ -116,10 +116,10 @@
         </span>
       </div>
       <div class="panel tw-bg-gray-50 tw-text-gray-900">
-        <a href="{{ albion_collection_url }}?filter.p.tag=ファンデーション#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>ファンデーション</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=メイクアップベース#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>メイクアップベース</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=コンシーラー#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>コンシーラー</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=フェイスパウダー#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>フェイスパウダー</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/ファンデーション#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>ファンデーション</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/メイクアップベース#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>メイクアップベース</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/コンシーラー#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>コンシーラー</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/フェイスパウダー#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>フェイスパウダー</span><i class="mdi mdi-chevron-right"></i></a>
       </div>
     </li>
     {% comment %} ポイントメイク {% endcomment %}
@@ -132,12 +132,12 @@
         </span>
       </div>
       <div class="panel tw-bg-gray-50 tw-text-gray-900">
-        <a href="{{ albion_collection_url }}?filter.p.tag=アイメイク#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>アイメイク</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=リップメイク#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>リップメイク</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=チーク,ブラッシュ#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>チーク・フェイスカラー</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=ネイルカラー#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>ネイル</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=ネイルケア,リムーバー#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>ネイルリムーバー</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=ポイントメイクオフ#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>ポイントメイクオフ</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/アイメイク#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>アイメイク</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/リップメイク#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>リップメイク</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/チーク,ブラッシュ#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>チーク・フェイスカラー</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/ネイルカラー#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>ネイル</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/ネイルケア,リムーバー#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>ネイルリムーバー</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/ポイントメイクオフ#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>ポイントメイクオフ</span><i class="mdi mdi-chevron-right"></i></a>
       </div>
     </li>
     {% comment %} UV・ボディ・その他 {% endcomment %}
@@ -150,11 +150,11 @@
         </span>
       </div>
       <div class="panel tw-bg-gray-50 tw-text-gray-900">
-        <a href="{{ albion_collection_url }}?filter.p.tag=UVケア#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>UVケア</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=アウトバストリートメント#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>ハンド・ボディケア</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=ヘアケア#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>ヘアケア</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=コットン#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>コットン</span><i class="mdi mdi-chevron-right"></i></a>
-        <a href="{{ albion_collection_url }}?filter.p.tag=アクセサリー#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>その他</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/UVケア#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>UVケア</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/アウトバストリートメント#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>ハンド・ボディケア</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/ヘアケア#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>ヘアケア</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/コットン#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>コットン</span><i class="mdi mdi-chevron-right"></i></a>
+        <a href="{{ albion_collection_url }}/アクセサリー#Collection" class="tw-flex tw-justify-between tw-items-center tw-p-4 tw-no-underline tw-text-black"><span>その他</span><i class="mdi mdi-chevron-right"></i></a>
       </div>
     </li>
   </ul>
@@ -164,64 +164,64 @@
   <div class="tw-hidden md:tw-grid md:tw-grid-cols-4 md:tw-gap-1">
     {% comment %} スキンケア {% endcomment %}
     <div class="tw-group tw-relative tw-text-left hover:tw-bg-gray-100 tw-bg-white tw-text-gray-900 tw-border tw-border-gray-200">
-      <a class="tw-h-10 tw-px-4 tw-py-2 tw-flex tw-items-center tw-justify-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=スキンケア#Collection">
+      <a class="tw-h-10 tw-px-4 tw-py-2 tw-flex tw-items-center tw-justify-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/スキンケア#Collection">
         スキンケア
         <i aria-hidden="true" class="tw-inline-flex tw-text-2xl tw-leading-none notranslate mdi mdi-chevron-right"></i>
       </a>
       <div class="nested-menu group-hover:tw-block tw-hidden tw-bg-white tw-text-gray-900 tw-absolute tw-z-10 tw-w-full tw-border tw-border-gray-200 tw-shadow-md">
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=クレンジング#Collection">クレンジング</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=洗顔料#Collection">洗顔料</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=乳液#Collection">乳液</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=化粧水#Collection">化粧水</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=美容液#Collection">美容液</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=クリーム#Collection">クリーム</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=マッサージ#Collection">マッサージ</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=パック,マスク#Collection">パック</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=美容オイル#Collection">美容オイル</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=アイケア#Collection">アイケア</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=リップケア#Collection">リップケア</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=スペシャルケア#Collection">スペシャルケア・その他</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/クレンジング#Collection">クレンジング</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/洗顔料#Collection">洗顔料</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/乳液#Collection">乳液</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/化粧水#Collection">化粧水</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/美容液#Collection">美容液</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/クリーム#Collection">クリーム</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/マッサージ#Collection">マッサージ</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/パック,マスク#Collection">パック</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/美容オイル#Collection">美容オイル</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/アイケア#Collection">アイケア</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/リップケア#Collection">リップケア</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/スペシャルケア#Collection">スペシャルケア・その他</a>
       </div>
     </div>
     {% comment %} ベースメイク {% endcomment %}
     <div class="tw-group tw-relative tw-text-left hover:tw-bg-gray-100 tw-bg-white tw-text-gray-900 tw-border tw-border-gray-200">
-      <a class="tw-h-10 tw-px-4 tw-py-2 tw-flex tw-items-center tw-justify-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=ベースメイク#Collection">
+      <a class="tw-h-10 tw-px-4 tw-py-2 tw-flex tw-items-center tw-justify-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/ベースメイク#Collection">
         ベースメイク
         <i aria-hidden="true" class="tw-inline-flex tw-text-2xl tw-leading-none notranslate mdi mdi-chevron-right"></i>
       </a>
       <div class="nested-menu group-hover:tw-block tw-hidden tw-bg-white tw-text-gray-900 tw-absolute tw-z-10 tw-w-full tw-border tw-border-gray-200 tw-shadow-md">
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=ファンデーション#Collection">ファンデーション</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=メイクアップベース#Collection">メイクアップベース</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=コンシーラー#Collection">コンシーラー</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=フェイスパウダー#Collection">フェイスパウダー</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/ファンデーション#Collection">ファンデーション</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/メイクアップベース#Collection">メイクアップベース</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/コンシーラー#Collection">コンシーラー</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/フェイスパウダー#Collection">フェイスパウダー</a>
       </div>
     </div>
     {% comment %} ポイントメイク {% endcomment %}
     <div class="tw-group tw-relative tw-text-left hover:tw-bg-gray-100 tw-bg-white tw-text-gray-900 tw-border tw-border-gray-200">
-      <a class="tw-h-10 tw-px-4 tw-py-2 tw-flex tw-items-center tw-justify-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=ポイントメイク#Collection">
+      <a class="tw-h-10 tw-px-4 tw-py-2 tw-flex tw-items-center tw-justify-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/ポイントメイク#Collection">
         ポイントメイク
         <i aria-hidden="true" class="tw-inline-flex tw-text-2xl tw-leading-none notranslate mdi mdi-chevron-right"></i>
       </a>
       <div class="nested-menu group-hover:tw-block tw-hidden tw-bg-white tw-text-gray-900 tw-absolute tw-z-10 tw-w-full tw-border tw-border-gray-200 tw-shadow-md">
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=アイメイク#Collection">アイメイク</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=リップメイク#Collection">リップメイク</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=チーク,ブラッシュ#Collection">チーク・フェイスカラー</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=ネイルカラー#Collection">ネイル</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=ネイルケア,リムーバー#Collection">ネイルリムーバー</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=ポイントメイクオフ#Collection">ポイントメイクオフ</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/アイメイク#Collection">アイメイク</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/リップメイク#Collection">リップメイク</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/チーク,ブラッシュ#Collection">チーク・フェイスカラー</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/ネイルカラー#Collection">ネイル</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/ネイルケア,リムーバー#Collection">ネイルリムーバー</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/ポイントメイクオフ#Collection">ポイントメイクオフ</a>
       </div>
     </div>
     <div class="tw-group tw-relative tw-text-left hover:tw-bg-gray-100 tw-bg-white tw-text-gray-900 tw-border tw-border-gray-200">
-      <a class="tw-h-10 tw-px-4 tw-py-2 tw-flex tw-items-center tw-justify-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=UVケア,アウトバストリートメント,ヘアケア,コットン,アクセサリー#Collection">
+      <a class="tw-h-10 tw-px-4 tw-py-2 tw-flex tw-items-center tw-justify-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/UVケア,アウトバストリートメント,ヘアケア,コットン,アクセサリー#Collection">
         UV・ボディ・その他
         <i aria-hidden="true" class="tw-inline-flex tw-text-2xl tw-leading-none notranslate mdi mdi-chevron-right"></i>
       </a>
       <div class="nested-menu group-hover:tw-block tw-hidden tw-bg-white tw-text-gray-900 tw-absolute tw-z-10 tw-w-full tw-border tw-border-gray-200 tw-shadow-md">
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=UVケア#Collection">UVケア</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=アウトバストリートメント#Collection">ハンド・ボディケア</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=ヘアケア#Collection">ヘアケア</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=コットン#Collection">コットン</a>
-        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}?filter.p.tag=アクセサリー#Collection">その他</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/UVケア#Collection">UVケア</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/アウトバストリートメント#Collection">ハンド・ボディケア</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/ヘアケア#Collection">ヘアケア</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/コットン#Collection">コットン</a>
+        <a class="tw-px-4 tw-py-2 tw-relative tw-text-left hover:tw-bg-gray-100 tw-flex tw-items-center tw-text-sm tw-tracking-widest tw-text-black tw-no-underline" href="{{ albion_collection_url }}/アクセサリー#Collection">その他</a>
       </div>
     </div>
   </div>

--- a/snippets/albion-series-finder.liquid
+++ b/snippets/albion-series-finder.liquid
@@ -15,62 +15,62 @@
   <div class="page-width">
     <ul class="tw-grid tw-grid-cols-2 sm:tw-grid-cols-4 tw-gap-4 tw-list-none tw-pl-0 tw-m-0">
       <li class="tw-m-0">
-        <a href="{{ albion_collection_url }}?filter.p.tag=フラルネ#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
+        <a href="{{ albion_collection_url }}/フラルネ#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
           <img src="{{ 'albion_series_flarune.jpg' | file_url }}" alt="FLARUNE" class="tw-max-w-full tw-max-h-full tw-w-auto tw-h-auto tw-object-contain" loading="lazy" width="300" height="300">
         </a>
       </li>
       <li class="tw-m-0">
-        <a href="{{ albion_collection_url }}?filter.p.tag=アンフィネス#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
+        <a href="{{ albion_collection_url }}/アンフィネス#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
           <img src="{{ 'albion_series_infinesse.jpg' | file_url }}" alt="INFINESSE" class="tw-max-w-full tw-max-h-full tw-w-auto tw-h-auto tw-object-contain" loading="lazy" width="300" height="300">
         </a>
       </li>
       <li class="tw-m-0">
-        <a href="{{ albion_collection_url }}?filter.p.tag=エクシア#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
+        <a href="{{ albion_collection_url }}/エクシア#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
           <img src="{{ 'albion_series_excia.jpg' | file_url }}" alt="EXCIA" class="tw-max-w-full tw-max-h-full tw-w-auto tw-h-auto tw-object-contain" loading="lazy" width="300" height="300">
         </a>
       </li>
       <li class="tw-m-0">
-        <a href="{{ albion_collection_url }}?filter.p.tag=エクシア アンベアージュ#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
+        <a href="{{ albion_collection_url }}/エクシア アンベアージュ#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
           <img src="{{ 'albion_series_embeage.jpg' | file_url }}" alt="EMBEAGE" class="tw-max-w-full tw-max-h-full tw-w-auto tw-h-auto tw-object-contain" loading="lazy" width="300" height="300">
         </a>
       </li>
       <li class="tw-m-0">
-        <a href="{{ albion_collection_url }}?filter.p.tag=アルビオン#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
+        <a href="{{ albion_collection_url }}/アルビオン#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
           <img src="{{ 'albion_series_albion.jpg' | file_url }}" alt="ALBION" class="tw-max-w-full tw-max-h-full tw-w-auto tw-h-auto tw-object-contain" loading="lazy" width="300" height="300">
         </a>
       </li>
       <li class="tw-m-0">
-        <a href="{{ albion_collection_url }}?filter.p.tag=アルビオンスタジオ#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
+        <a href="{{ albion_collection_url }}/アルビオンスタジオ#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
           <img src="{{ 'albion_series_albion_studio.jpg' | file_url }}" alt="ALBION STUDIO" class="tw-max-w-full tw-max-h-full tw-w-auto tw-h-auto tw-object-contain" loading="lazy" width="300" height="300">
         </a>
       </li>
       <li class="tw-m-0">
-        <a href="{{ albion_collection_url }}?filter.p.tag=エクスヴィ#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
+        <a href="{{ albion_collection_url }}/エクスヴィ#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
           <img src="{{ 'albion_series_ex_vie.jpg' | file_url }}" alt="EX-VIE" class="tw-max-w-full tw-max-h-full tw-w-auto tw-h-auto tw-object-contain" loading="lazy" width="300" height="300">
         </a>
       </li>
       <li class="tw-m-0">
-        <a href="{{ albion_collection_url }}?filter.p.tag=スーパー UV カット#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
+        <a href="{{ albion_collection_url }}/スーパー UV カット#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
           <img src="{{ 'albion_series_uv.jpg' | file_url }}" alt="UV" class="tw-max-w-full tw-max-h-full tw-w-auto tw-h-auto tw-object-contain" loading="lazy" width="300" height="300">
         </a>
       </li>
       <li class="tw-m-0">
-        <a href="{{ albion_collection_url }}?filter.p.tag=スパランカ#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
+        <a href="{{ albion_collection_url }}/スパランカ#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
           <img src="{{ 'albion_series_spalanka.jpg' | file_url }}" alt="SPALANKA" class="tw-max-w-full tw-max-h-full tw-w-auto tw-h-auto tw-object-contain" loading="lazy" width="300" height="300">
         </a>
       </li>
       <li class="tw-m-0">
-        <a href="{{ albion_collection_url }}?filter.p.tag=ルネセア#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
+        <a href="{{ albion_collection_url }}/ルネセア#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
           <img src="{{ 'albion_series_renasair.jpg' | file_url }}" alt="RENASAIR" class="tw-max-w-full tw-max-h-full tw-w-auto tw-h-auto tw-object-contain" loading="lazy" width="300" height="300">
         </a>
       </li>
       <li class="tw-m-0">
-        <a href="{{ albion_collection_url }}?filter.p.tag=ジュイール#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
+        <a href="{{ albion_collection_url }}/ジュイール#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
           <img src="{{ 'albion_series_jouir.jpg' | file_url }}" alt="JOUIR" class="tw-max-w-full tw-max-h-full tw-w-auto tw-h-auto tw-object-contain" loading="lazy" width="300" height="300">
         </a>
       </li>
       <li class="tw-m-0">
-        <a href="{{ albion_collection_url }}?filter.p.tag=フィオナ#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
+        <a href="{{ albion_collection_url }}/フィオナ#Collection" class="tw-block tw-aspect-[17/8] tw-bg-white tw-overflow-hidden tw-no-underline hover:tw-opacity-80 tw-flex tw-items-center tw-justify-center tw-p-4" style="border: 1px solid #dddddd;">
           <img src="{{ 'albion_series_fiona.jpg' | file_url }}" alt="FIONA" class="tw-max-w-full tw-max-h-full tw-w-auto tw-h-auto tw-object-contain" loading="lazy" width="300" height="300">
         </a>
       </li>

--- a/snippets/buy-buttons.liquid
+++ b/snippets/buy-buttons.liquid
@@ -15,7 +15,7 @@
   assign counseling_scope = ''
   if slug == 'cle-de-peau-beaute' or slug == 'shiseido' or slug == 'benefique' or slug == 'shiseido-men' or slug == 'inoui'
     assign counseling_scope = 'shiseido-group'
-  elsif slug == 'decorte'
+  elsif slug == 'decorte' or slug == 'predia'
     assign counseling_scope = 'decorte-group'
   elsif slug == 'albion' or slug == 'elegance' or slug == 'ignis'
     assign counseling_scope = 'albion-group'

--- a/snippets/buy-buttons.liquid
+++ b/snippets/buy-buttons.liquid
@@ -11,6 +11,16 @@
   {% render 'buy-buttons', block: block, product: product, product_form_id: product_form_id, section_id: section.id, show_pickup_availability: true %}
 {% endcomment %}
 {% assign slug = product.metafields.my_fields.vendor_slug %}
+{%- liquid
+  assign counseling_scope = ''
+  if slug == 'cle-de-peau-beaute' or slug == 'shiseido' or slug == 'benefique' or slug == 'shiseido-men' or slug == 'inoui'
+    assign counseling_scope = 'shiseido-group'
+  elsif slug == 'decorte'
+    assign counseling_scope = 'decorte-group'
+  elsif slug == 'albion' or slug == 'elegance' or slug == 'ignis'
+    assign counseling_scope = 'albion-group'
+  endif
+-%}
 
 <div {{ block.shopify_attributes }}>
   {%- if product != blank -%}
@@ -30,6 +40,9 @@
         class="product-form"
         data-hide-errors="{{ gift_card_recipient_feature_active }}"
         data-section-id="{{ section.id }}"
+        {% if counseling_scope != blank %}
+          data-counseling-scope="{{ counseling_scope }}"
+        {% endif %}
     >
       <div class="product-form__error-message-wrapper" role="alert" hidden>
         <svg

--- a/snippets/cart-question-albion.liquid
+++ b/snippets/cart-question-albion.liquid
@@ -9,7 +9,7 @@
   }
 </style>
 
-<my-dialog id="myDialog" data-brand="albion" data-input-type="checkbox">
+<my-dialog id="myDialog" data-brand="albion" data-input-type="checkbox" data-counseling-scope="albion-group">
   <dialog class="tw-w-[600px] tw-max-w-[90%]">
     <div class="page">
       <div class="counseling-content">
@@ -118,4 +118,3 @@
     </div>
   </dialog>
 </my-dialog>
-

--- a/snippets/cart-question-cpb.liquid
+++ b/snippets/cart-question-cpb.liquid
@@ -14,7 +14,7 @@
   }
 </style>
 
-<my-dialog id="myDialog">
+<my-dialog id="myDialog" data-counseling-scope="shiseido-group">
   <dialog class="tw-w-[600px] tw-max-w-[90%]">
     <div class="page">
       <div class="counseling-content tw-p-2 md:tw-p-6">

--- a/snippets/cart-question-decorte.liquid
+++ b/snippets/cart-question-decorte.liquid
@@ -9,7 +9,7 @@
   }
 </style>
 
-<my-dialog id="myDialog" data-brand="decorte">
+<my-dialog id="myDialog" data-brand="decorte" data-counseling-scope="decorte-group">
   <dialog class="tw-w-[600px] tw-max-w-[90%]">
     <div class="page">
       <div class="counseling-content">

--- a/snippets/cart-question-predia.liquid
+++ b/snippets/cart-question-predia.liquid
@@ -3,7 +3,7 @@
 <script src="{{ 'dialog-polyfill.js' | asset_url }}" defer="defer"></script>
 <script src="{{ 'counseling-modal.js' | asset_url }}" defer="defer"></script>
 
-<my-dialog id="myDialog" data-brand="predia">
+<my-dialog id="myDialog" data-brand="predia" data-counseling-scope="decorte-group">
   <dialog class="tw-w-[600px] tw-max-w-[90%]">
     <div class="page">
       <div class="counseling-content tw-p-2 md:tw-p-6">


### PR DESCRIPTION
## Summary
- Add 24-hour counseling approval persistence in `localStorage` for Decorte, Shiseido-group, and Albion-group products
- Skip reopening counseling modals when a valid approval exists and submit the product form directly
- Pass counseling scope from buy buttons into each brand modal and align submit handling with the actual clicked submit button

## Testing
- `npm run build`
- Browser verification on local theme preview for Decorte, Shiseido, and Albion-group flows
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/perfumerie-sukiya/dawn/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * カウンセリング承認をスコープ別に24時間保存する機能を追加しました。
  * 承認がある場合、モーダルを介さず対象の購入フォームを直接送信する動作を追加しました。

* **改善**
  * ダイアログの状態管理と結果追跡を強化し、購入可能な結果で承認を自動保存するようにしました。
  * 送信時のローディング表示とエラー処理を堅牢化しました。
  * カウンセリング起動の初期化とクリック取り扱いを最適化しました。

* **変更**
  * 一部カテゴリ・シリーズのリンクURLをクエリ形式からパス形式へ変更しました。
  * 製品フォームおよびダイアログにカウンセリングスコープ属性を追加しました。
  * アナウンスメントリンクの矢印装飾を削除し下線スタイルを調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->