### PR TITLE
GWPアイテムをカート内の最後に表示する

### DIFF
--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -99,7 +99,14 @@
               </thead>
 
               <tbody>
+                {%- comment -%} GWPアイテムをカートの末尾に表示するため、非GWP→GWPの順で2パス描画 {%- endcomment -%}
+                {%- for gwp_pass in (0..1) -%}
                 {%- for item in cart.items -%}
+                  {%- if item.product.template_suffix == 'gwp' -%}
+                    {%- if gwp_pass == 0 -%}{%- continue -%}{%- endif -%}
+                  {%- else -%}
+                    {%- if gwp_pass == 1 -%}{%- continue -%}{%- endif -%}
+                  {%- endif -%}
                   <tr class="cart-item" id="CartItem-{{ item.index | plus: 1 }}">
                     <td class="cart-item__media">
                       {% if item.image %}
@@ -457,6 +464,7 @@
                       </div>
                     </td>
                   </tr>
+                {%- endfor -%}
                 {%- endfor -%}
               </tbody>
             </table>

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -113,7 +113,14 @@
                   </thead>
 
                   <tbody role="rowgroup">
+                    {%- comment -%} GWPアイテムをカートの末尾に表示するため、非GWP→GWPの順で2パス描画 {%- endcomment -%}
+                    {%- for gwp_pass in (0..1) -%}
                     {%- for item in cart.items -%}
+                      {%- if item.product.template_suffix == 'gwp' -%}
+                        {%- if gwp_pass == 0 -%}{%- continue -%}{%- endif -%}
+                      {%- else -%}
+                        {%- if gwp_pass == 1 -%}{%- continue -%}{%- endif -%}
+                      {%- endif -%}
                       <tr id="CartDrawer-Item-{{ item.index | plus: 1 }}" class="cart-item" role="row">
                         <td class="cart-item__media" role="cell" headers="CartDrawer-ColumnProductImage">
                           {% if item.image %}
@@ -434,6 +441,7 @@
                           </quantity-popover>
                         </td>
                       </tr>
+                    {%- endfor -%}
                     {%- endfor -%}
                   </tbody>
                 </table>


### PR DESCRIPTION
## Summary
- GWP（ノベルティ）がカート内で一番最後に表示されるよう修正
- 2パスループで通常商品→GWPの順にレンダリング
- GWP識別: `item.product.template_suffix == 'gwp'`（`product.gwp.json` テンプレート使用商品）
- カートページ・カートドロワーの両方に適用

## 変更ファイル
- `sections/main-cart-items.liquid`
- `snippets/cart-drawer.liquid`

## Test plan
- [ ] カートに通常商品とGWP商品を入れ、GWPが最後に表示されることを確認
- [ ] カートドロワーでも同様の順序で表示されることを確認
- [ ] GWP商品がない場合に通常通り表示されることを確認
- [ ] 数量変更・削除が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/perfumerie-sukiya/dawn/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * カート内のアイテム表示順序を最適化しました。通常のアイテムがギフト対象アイテムより先に表示されるよう改善されました。カートドロワーのアイテム表示ロジックも同時に更新され、全体で一貫した表示順序が実現されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->