### PR TITLE
Algolia autocomplete の価格が SP で $ 表記になる問題を修正

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -39,24 +39,56 @@
     {{ content_for_header }}
 
     <script>
-      document.addEventListener('algolia.hooks.initialize', function () {
-        if (!window.algoliaShopify) return;
-
-        var originalFormatMoney = window.algoliaShopify.formatMoney;
-
-        window.algoliaShopify.formatMoney = function (cents, currencyCode) {
-          if (currencyCode && String(currencyCode).toUpperCase() !== 'JPY' && typeof originalFormatMoney === 'function') {
-            return originalFormatMoney(cents, currencyCode);
+      (function () {
+        function jpyFormat(cents, currencyCode, originalFn) {
+          if (currencyCode && String(currencyCode).toUpperCase() !== 'JPY' && typeof originalFn === 'function') {
+            return originalFn(cents, currencyCode);
           }
-
           var value = (Number(cents) / 100).toLocaleString('ja-JP', {
             minimumFractionDigits: 0,
             maximumFractionDigits: 0,
           });
-
           return '¥' + value;
-        };
-      });
+        }
+
+        function installFormatMoneySetter(target) {
+          if (!target || target.__jpyFormatMoneyInstalled) return;
+          target.__jpyFormatMoneyInstalled = true;
+
+          var raw = target.formatMoney;
+          var wrapped = function (cents, currencyCode) {
+            return jpyFormat(cents, currencyCode, raw);
+          };
+
+          Object.defineProperty(target, 'formatMoney', {
+            configurable: true,
+            enumerable: true,
+            get: function () { return wrapped; },
+            set: function (next) {
+              raw = next;
+              wrapped = function (cents, currencyCode) {
+                return jpyFormat(cents, currencyCode, raw);
+              };
+            }
+          });
+        }
+
+        if (window.algoliaShopify) {
+          installFormatMoneySetter(window.algoliaShopify);
+          return;
+        }
+
+        var stored;
+        Object.defineProperty(window, 'algoliaShopify', {
+          configurable: true,
+          enumerable: true,
+          get: function () { return stored; },
+          set: function (next) {
+            stored = next;
+            installFormatMoneySetter(stored);
+          }
+        });
+      })();
     </script>
 
     {%- liquid

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -40,36 +40,30 @@
 
     <script>
       (function () {
-        function jpyFormat(cents, currencyCode, originalFn) {
-          if (currencyCode && String(currencyCode).toUpperCase() !== 'JPY' && typeof originalFn === 'function') {
-            return originalFn(cents, currencyCode);
-          }
-          var value = (Number(cents) / 100).toLocaleString('ja-JP', {
-            minimumFractionDigits: 0,
-            maximumFractionDigits: 0,
-          });
-          return '¥' + value;
-        }
-
         function installFormatMoneySetter(target) {
           if (!target || target.__jpyFormatMoneyInstalled) return;
           target.__jpyFormatMoneyInstalled = true;
 
           var raw = target.formatMoney;
           var wrapped = function (cents, currencyCode) {
-            return jpyFormat(cents, currencyCode, raw);
+            var isNonJpy = currencyCode && String(currencyCode).toUpperCase() !== 'JPY';
+            var amount = Number(cents);
+            if (typeof raw === 'function' && (isNonJpy || !isFinite(amount))) {
+              return raw.apply(this, arguments);
+            }
+            if (!isFinite(amount)) return '';
+            var value = (amount / 100).toLocaleString('ja-JP', {
+              minimumFractionDigits: 0,
+              maximumFractionDigits: 0,
+            });
+            return '¥' + value;
           };
 
           Object.defineProperty(target, 'formatMoney', {
             configurable: true,
             enumerable: true,
             get: function () { return wrapped; },
-            set: function (next) {
-              raw = next;
-              wrapped = function (cents, currencyCode) {
-                return jpyFormat(cents, currencyCode, raw);
-              };
-            }
+            set: function (next) { raw = next; }
           });
         }
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -45,19 +45,21 @@
           target.__jpyFormatMoneyInstalled = true;
 
           var raw = target.formatMoney;
-          var wrapped = function (cents, currencyCode) {
-            var isNonJpy = currencyCode && String(currencyCode).toUpperCase() !== 'JPY';
-            var amount = Number(cents);
-            if (typeof raw === 'function' && (isNonJpy || !isFinite(amount))) {
-              return raw.apply(this, arguments);
-            }
-            if (!isFinite(amount)) return '';
-            var value = (amount / 100).toLocaleString('ja-JP', {
-              minimumFractionDigits: 0,
-              maximumFractionDigits: 0,
-            });
-            return '¥' + value;
-          };
+          var wrapped = (function (currentRaw) {
+            return function (cents, currencyCode) {
+              var isNonJpy = currencyCode && String(currencyCode).toUpperCase() !== 'JPY';
+              var amount = Number(cents);
+              if (typeof currentRaw === 'function' && (isNonJpy || !isFinite(amount))) {
+                return currentRaw.apply(this, arguments);
+              }
+              if (!isFinite(amount)) return '';
+              var value = (amount / 100).toLocaleString('ja-JP', {
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 0,
+              });
+              return '¥' + value;
+            };
+          })(raw);
 
           Object.defineProperty(target, 'formatMoney', {
             configurable: true,
@@ -65,19 +67,21 @@
             get: function () { return wrapped; },
             set: function (next) {
               raw = next;
-              wrapped = function (cents, currencyCode) {
-                var isNonJpy = currencyCode && String(currencyCode).toUpperCase() !== 'JPY';
-                var amount = Number(cents);
-                if (typeof raw === 'function' && (isNonJpy || !isFinite(amount))) {
-                  return raw.apply(this, arguments);
-                }
-                if (!isFinite(amount)) return '';
-                var value = (amount / 100).toLocaleString('ja-JP', {
-                  minimumFractionDigits: 0,
-                  maximumFractionDigits: 0,
-                });
-                return '¥' + value;
-              };
+              wrapped = (function (currentRaw) {
+                return function (cents, currencyCode) {
+                  var isNonJpy = currencyCode && String(currencyCode).toUpperCase() !== 'JPY';
+                  var amount = Number(cents);
+                  if (typeof currentRaw === 'function' && (isNonJpy || !isFinite(amount))) {
+                    return currentRaw.apply(this, arguments);
+                  }
+                  if (!isFinite(amount)) return '';
+                  var value = (amount / 100).toLocaleString('ja-JP', {
+                    minimumFractionDigits: 0,
+                    maximumFractionDigits: 0,
+                  });
+                  return '¥' + value;
+                };
+              })(raw);
             }
           });
         }

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -40,26 +40,28 @@
 
     <script>
       (function () {
+        function createFormatMoneyWrapper(currentRaw) {
+          return function (cents, currencyCode) {
+            var isNonJpy = currencyCode && String(currencyCode).toUpperCase() !== 'JPY';
+            var amount = Number(cents);
+            if (typeof currentRaw === 'function' && (isNonJpy || !isFinite(amount))) {
+              return currentRaw.apply(this, arguments);
+            }
+            if (!isFinite(amount)) return '';
+            var value = (amount / 100).toLocaleString('ja-JP', {
+              minimumFractionDigits: 0,
+              maximumFractionDigits: 0,
+            });
+            return '¥' + value;
+          };
+        }
+
         function installFormatMoneySetter(target) {
           if (!target || target.__jpyFormatMoneyInstalled) return;
           target.__jpyFormatMoneyInstalled = true;
 
           var raw = target.formatMoney;
-          var wrapped = (function (currentRaw) {
-            return function (cents, currencyCode) {
-              var isNonJpy = currencyCode && String(currencyCode).toUpperCase() !== 'JPY';
-              var amount = Number(cents);
-              if (typeof currentRaw === 'function' && (isNonJpy || !isFinite(amount))) {
-                return currentRaw.apply(this, arguments);
-              }
-              if (!isFinite(amount)) return '';
-              var value = (amount / 100).toLocaleString('ja-JP', {
-                minimumFractionDigits: 0,
-                maximumFractionDigits: 0,
-              });
-              return '¥' + value;
-            };
-          })(raw);
+          var wrapped = createFormatMoneyWrapper(raw);
 
           Object.defineProperty(target, 'formatMoney', {
             configurable: true,
@@ -67,21 +69,7 @@
             get: function () { return wrapped; },
             set: function (next) {
               raw = next;
-              wrapped = (function (currentRaw) {
-                return function (cents, currencyCode) {
-                  var isNonJpy = currencyCode && String(currencyCode).toUpperCase() !== 'JPY';
-                  var amount = Number(cents);
-                  if (typeof currentRaw === 'function' && (isNonJpy || !isFinite(amount))) {
-                    return currentRaw.apply(this, arguments);
-                  }
-                  if (!isFinite(amount)) return '';
-                  var value = (amount / 100).toLocaleString('ja-JP', {
-                    minimumFractionDigits: 0,
-                    maximumFractionDigits: 0,
-                  });
-                  return '¥' + value;
-                };
-              })(raw);
+              wrapped = createFormatMoneyWrapper(raw);
             }
           });
         }

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -63,7 +63,22 @@
             configurable: true,
             enumerable: true,
             get: function () { return wrapped; },
-            set: function (next) { raw = next; }
+            set: function (next) {
+              raw = next;
+              wrapped = function (cents, currencyCode) {
+                var isNonJpy = currencyCode && String(currencyCode).toUpperCase() !== 'JPY';
+                var amount = Number(cents);
+                if (typeof raw === 'function' && (isNonJpy || !isFinite(amount))) {
+                  return raw.apply(this, arguments);
+                }
+                if (!isFinite(amount)) return '';
+                var value = (amount / 100).toLocaleString('ja-JP', {
+                  minimumFractionDigits: 0,
+                  maximumFractionDigits: 0,
+                });
+                return '¥' + value;
+              };
+            }
           });
         }
 


### PR DESCRIPTION
## Summary

- 検索バー入力時の Algolia autocomplete サジェストで、価格が `$990.00` のようにドル表記で出てしまう不具合を修正
- これまで `algolia.hooks.initialize` イベントを待って `algoliaShopify.formatMoney` を上書きしていたが、Algolia アプリ側のスクリプトが後から `formatMoney` を再代入するケースがあり、上書きが失われて元のフォーマット（`{{ shop.money_format }}`）に戻っていた
- `Object.defineProperty` の setter で `formatMoney` を常時ラップするように変更。`window.algoliaShopify` が未定義のタイミングで読み込まれた場合にも対応

## 変更点

`layout/theme.liquid` の `<head>` 内オーバーライドスクリプトを書き直し:

- `window.algoliaShopify` がまだ無ければ `window` 側に setter を仕込んで生成を待つ
- 生成後は `algoliaShopify.formatMoney` を accessor property に置き換え、後段で再代入されても自動的に JPY 用ラッパーを再構築する
- `currencyCode` が JPY 以外（USD/EUR 等）の場合のみ元の関数に委譲する挙動は据え置き

## Test plan

- [ ] 本番テーマにデプロイ後、SP（実機 / Chrome iPhone エミュレート）で検索バーに任意のキーワードを入力し、サジェストの商品価格が `¥990` のように円表記で表示されることを確認
- [ ] PC でも同様に円表記で表示されることを確認（リグレッション無し）
- [ ] `/search` ページの InstantSearch 結果も円表記であること
- [ ] 検索モーダルを開閉しても価格表記が崩れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 日本円（JPY）の通貨表示を安定化しました。無効・非数値の金額は空欄表示になり、整数の「¥」付き表記で一貫して表示されます。
  * 表示処理の二重適用を防ぎ、既存の通貨フォーマッタがある場合は適切に委譲して信頼性を向上させます。
  * フォーマッタが後から登録・差し替えられても自動で反映されるよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/perfumerie-sukiya/dawn/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
