### PR TITLE
GWPアプリのカート送信URLをApp Proxyに変更

### DIFF
--- a/assets/cart.js
+++ b/assets/cart.js
@@ -190,7 +190,7 @@ class CartItems extends HTMLElement {
   }
   async sendCartToApp(cart) {
     try {
-      const response = await fetch('https://shopify-gwp-app.onrender.com/api/getcart', {
+      const response = await fetch('/apps/gwp/getcart', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -118,7 +118,7 @@ if (!customElements.get('product-form')) {
 
       async sendCartToApp(cart) {
         try {
-          const response = await fetch('https://shopify-gwp-app.onrender.com/api/getcart', {
+          const response = await fetch('/apps/gwp/getcart', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
- GWP（Gift With Purchase）アプリへのカート送信先を、外部URL `https://shopify-gwp-app.onrender.com/api/getcart` から App Proxy パス `/apps/gwp/getcart` に変更
- 変更対象: `assets/cart.js`（カートページ）と `assets/product-form.js`（商品ページからのカート追加）

## 背景
App Proxy 経由にすることで、同一オリジンからのリクエストとなり CORS の問題を回避し、Shopify ストアドメイン経由で GWP アプリにアクセスできるようになります。

## Test plan
- [ ] 商品ページでカートに追加し、GWP 特典の付与が正常に動作すること
- [ ] カートページで数量変更・削除後も GWP 連携が正常に動作すること
- [ ] ブラウザ DevTools の Network タブで `/apps/gwp/getcart` への POST が 200 を返すこと


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/perfumerie-sukiya/dawn/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->