### PR TITLE
GWP: テーマ直書きスクリプトを削除（App Embed 移行）

### DIFF
--- a/assets/cart.js
+++ b/assets/cart.js
@@ -168,12 +168,6 @@ class CartItems extends HTMLElement {
         }
 
         publish(PUB_SUB_EVENTS.cartUpdate, { source: 'cart-items', cartData: parsedState, variantId: variantId });
-        const cart = this.getCartFromCookies();
-        if (cart) {
-          this.sendCartToApp(cart);
-        } else {
-          console.log('Failed to get cart Id');
-        }
       })
       .catch(() => {
         this.querySelectorAll('.loading__spinner').forEach((overlay) => overlay.classList.add('hidden'));
@@ -183,29 +177,6 @@ class CartItems extends HTMLElement {
       .finally(() => {
         this.disableLoading(line);
       });
-  }
-  getCartFromCookies() {
-    const cookieValue = document.cookie.replace(/(?:(?:^|.*;\s*)cart\s*\=\s*([^;]*).*$)|^.*$/, "$1");
-    return cookieValue ? decodeURIComponent(cookieValue) : null;
-  }
-  async sendCartToApp(cart) {
-    try {
-      const response = await fetch('/apps/gwp/getcart', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ cartId: cart }),
-      });
-  
-      if (response.ok) {
-        this.onCartUpdate();
-      } else {
-        console.error('app error');
-      }
-    } catch (error) {
-      console.error('sending error:', error);
-    }
   }
 
   updateLiveRegions(line, message) {

--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -76,12 +76,6 @@ if (!customElements.get('product-form')) {
                 cartData: response,
               });
             this.error = false;
-            const cart = this.getCartFromCookies();
-            if (cart) {
-              this.sendCartToApp(cart);
-            } else {
-              console.log('Failed to get cart Id');
-            }
             const quickAddModal = this.closest('quick-add-modal');
             if (quickAddModal) {
               document.body.addEventListener(
@@ -109,29 +103,6 @@ if (!customElements.get('product-form')) {
               loadingSpinner.classList.add('hidden');
             }
           });
-      }
-
-      getCartFromCookies() {
-        const cookieValue = document.cookie.replace(/(?:(?:^|.*;\s*)cart\s*\=\s*([^;]*).*$)|^.*$/, "$1");
-        return cookieValue ? decodeURIComponent(cookieValue) : null;
-      }
-
-      async sendCartToApp(cart) {
-        try {
-          const response = await fetch('/apps/gwp/getcart', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ cartId: cart }),
-          });
-
-          if (!response.ok){
-            console.error('app error');
-          }
-        } catch (error) {
-          console.error('sending error:', error);
-        }
       }
 
       handleErrorMessage(errorMessage = false) {


### PR DESCRIPTION
## Summary

- `assets/cart.js` と `assets/product-form.js` から GWP 用の `sendCartToApp` / `getCartFromCookies` 呼び出しを削除
- ストアフロント側の GWP チェックは `gift-bear` アプリの **Theme App Extension（App Embed）** に移管する前提の変更

## 背景

これまでテーマ JS が `/apps/gwp/getcart` を直接呼んでいたため、GWP の挙動変更のたびに dawn テーマのデプロイが必要でした。App Embed 化により、アプリ側のデプロイだけでストアフロント JS を更新できるようにします。

## マージ順序

**この PR をマージする前に**、以下を完了してください。

1. `shopify-GWP-app` 側で Theme App Extension を追加・デプロイ
2. テストストアのテーマエディタで **App embeds → gift-bear GWP** を有効化

マージ後に App Embed が未有効だと、GWP チェックが一切走らなくなります。

## Test plan

- [ ] App Embed 有効化後、商品ページ表示で `getcart` が呼ばれること
- [ ] カート追加・数量変更後も `getcart` が呼ばれること
- [ ] 条件を満たすカートでギフトが付与されること
- [ ] 条件を満たさないカートでギフトが削除されること
- [ ] App Embed 無効時は GWP が動かないこと（移行確認用）


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/perfumerie-sukiya/dawn/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->