### PR TITLE
BLUEコレクションページにメタフィールド駆動のCAMPAIGN枠を追加

### DIFF
--- a/sections/main-collection-product-grid-predia-blue.liquid
+++ b/sections/main-collection-product-grid-predia-blue.liquid
@@ -396,7 +396,7 @@
           </slider-component>
         </div>
       {%- endif -%}
-      <div id="campaign"></div>
+      {% render 'campaign-blue' %}
       <div id="ranking"></div>
       {%- if ranking_products_to_display > 0 -%}
         <div class="cpb-items tw-my-10">

--- a/sections/main-collection-product-grid-sekkisei-blue.liquid
+++ b/sections/main-collection-product-grid-sekkisei-blue.liquid
@@ -394,7 +394,7 @@
           </slider-component>
         </div>
       {%- endif -%}
-      <div id="campaign"></div>
+      {% render 'campaign-blue' %}
       <div id="ranking"></div>
       {%- if ranking_products_to_display > 0 -%}
         <div class="cpb-items tw-my-10">

--- a/snippets/campaign-blue.liquid
+++ b/snippets/campaign-blue.liquid
@@ -1,0 +1,40 @@
+{%- comment -%}
+  BLUEコレクション共通のキャンペーンバナー。
+  コレクションのメタフィールド custom.campaigns（list.metaobject_reference）に
+  紐づいたキャンペーンメタオブジェクト（type: campaign）を描画する。
+  未設定時はアンカー用の空divのみ残す。
+{%- endcomment -%}
+{%- assign campaigns = collection.metafields.custom.campaigns.value -%}
+<div id="campaign">
+  {%- if campaigns.count > 0 -%}
+    <div class="cpb-items tw-my-10">
+      <h3 class="tw-text-center tw-text-3xl tw-font-bold tw-mb-6">CAMPAIGN</h3>
+      <div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 tw-gap-4">
+        {%- for campaign in campaigns -%}
+          {%- assign image_pc = campaign.image.value -%}
+          {%- assign image_sp = campaign.image_sp.value | default: image_pc -%}
+          {%- if image_pc -%}
+            <div>
+              {% if campaign.link.value %}<a href="{{ campaign.link.value }}" class="tw-text-current">{% endif %}
+              <picture>
+                <source
+                  media="(max-width: 767px)"
+                  srcset="{{ image_sp | image_url: width: 750 }}"
+                >
+                <img
+                  src="{{ image_pc | image_url: width: 1230 }}"
+                  alt="{{ campaign.title.value | escape }}"
+                  width="{{ image_pc.width }}"
+                  height="{{ image_pc.height }}"
+                  loading="lazy"
+                  class="tw-block tw-w-full"
+                >
+              </picture>
+              {% if campaign.link.value %}</a>{% endif %}
+            </div>
+          {%- endif -%}
+        {%- endfor -%}
+      </div>
+    </div>
+  {%- endif -%}
+</div>

--- a/snippets/campaign-blue.liquid
+++ b/snippets/campaign-blue.liquid
@@ -5,8 +5,14 @@
   未設定時はアンカー用の空divのみ残す。
 {%- endcomment -%}
 {%- assign campaigns = collection.metafields.custom.campaigns.value -%}
+{%- assign banner_count = 0 -%}
+{%- for campaign in campaigns -%}
+  {%- if campaign.image.value -%}
+    {%- assign banner_count = banner_count | plus: 1 -%}
+  {%- endif -%}
+{%- endfor -%}
 <div id="campaign">
-  {%- if campaigns.count > 0 -%}
+  {%- if banner_count > 0 -%}
     <div class="cpb-items tw-my-10">
       <h3 class="tw-text-center tw-text-3xl tw-font-bold tw-mb-6">CAMPAIGN</h3>
       <div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 tw-gap-4">


### PR DESCRIPTION
## 概要
predia-blue / 雪肌精BLUE のコレクションページで、これまで空のアンカー(`<div id="campaign">`)だった CAMPAIGN 枠に、コレクションのメタフィールドからキャンペーンバナーを描画するようにしました。

## 変更内容
- `snippets/campaign-blue.liquid` を新規追加(両ブランド共通)
  - コレクションメタフィールド `custom.campaigns`(campaign メタオブジェクトのリスト参照)を読み取り描画
  - PC(768px〜)は2列グリッド、SPは1列
  - SP用画像(`image_sp`)が設定されていればSPで差し替え、リンクは任意
  - メタフィールド未設定時は `#campaign` アンカーのみ残す(ナビのスクロール先は維持)
- 両セクションの空だったプレースホルダを `{% render 'campaign-blue' %}` に置き換え
- 使用している Tailwind クラスはすべてビルド済み main.css に存在するもののため、CSS の再ビルドは不要

## ストア側の設定(テスト環境 perfumerie-sukiya-online-test に作成済み)
- メタオブジェクト定義 `campaign`(タイトル/PC画像/SP画像/リンク、公開ステータス付き)
- コレクションメタフィールド定義 `custom.campaigns`(ピン留め済み)
- サンプルデータ3件投入済み(Prédia用 / 雪肌精用 / 両ブランド共通)
- ⚠️ 本番ストアへ展開する際は、同じ定義を本番側にも作成する必要があります

## 動作確認
- `shopify theme dev --store perfumerie-sukiya-online-test.myshopify.com` にて確認
- 両コレクションページで CAMPAIGN 見出しとバナー2件が表示されること、PCで2列・SPで1列になること、未設定コレクションでは何も表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/perfumerie-sukiya/dawn/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->